### PR TITLE
Added support for card number length

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ CreditCardForm(
 | `hideCardHolder`     | default (false)                                              |
 | `expiredDateLabel`   | label for expired date input                                 |
 | `cvcLabel`           | label for security code                                      |
+| `cardNumberLength`   | length for card number. default (16)                         |
 | `cvcLength`          | length for security code. default (4)                        |
 | `cvcIcon`            | Icon widget for security code.                               |
 | `fontSize`           | font size for all inputs and labels. default (16)            |

--- a/lib/component.dart
+++ b/lib/component.dart
@@ -7,6 +7,7 @@ class CreditCardForm extends StatefulWidget {
   final String? expiredDateLabel;
   final String? cvcLabel;
   final Widget? cvcIcon;
+  final int? cardNumberLength;
   final int? cvcLength;
   final double fontSize;
   final CreditCardTheme? theme;
@@ -22,6 +23,7 @@ class CreditCardForm extends StatefulWidget {
     this.expiredDateLabel,
     this.cvcLabel,
     this.cvcIcon,
+    this.cardNumberLength = 16,
     this.cvcLength = 4,
     this.fontSize = 16,
     this.controller,
@@ -91,7 +93,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
             bottom: 1,
             formatters: [
               FilteringTextInputFormatter.digitsOnly,
-              LengthLimitingTextInputFormatter(19),
+              LengthLimitingTextInputFormatter(widget.cardNumberLength),
               CardNumberInputFormatter(),
             ],
             onChanged: (val) {


### PR DESCRIPTION
Use `cardNumberLength` to give the dynamic length of a credit card. Set the default as 16.